### PR TITLE
Sherlock SDSS betterName TypeError workaround

### DIFF
--- a/sherlock/transient_classifier.py
+++ b/sherlock/transient_classifier.py
@@ -1973,7 +1973,12 @@ END""" % locals())
                 dec=match["decDeg"],
                 delimiter=""
             )
-            betterName = "SDSS J" + ra[0:9] + dec[0:9]
+            # 2025-07-17 KWS Added a quick workaround for when the ra or dec are not parseable.
+            try:
+                betterName = "SDSS J" + ra[0:9] + dec[0:9]
+            except TypeError as e:
+                print("ERROR", ra, dec, objectId)
+                betterName = ''
             objectId = '''<a href="%(objectId)s">%(betterName)s</a>''' % locals()
         elif "milliquas" in catalogue.lower():
             thisName = objectId


### PR DESCRIPTION
Added a quick workaround for when the SDSS ra or dec are not parseable and the attempt to produce an betterName is thwarted by a TypeError.  Worth investigating more deeply what triggers this, but this will let Sherlock continue.